### PR TITLE
Update and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,46 @@
-# Batex
-Export selected objects as fbx in batch operation.
+# Batex - Batch Export as FBX
 
-### Features
-* One fbx file per selected object
-* Set the pivot point to center before exporting (useful e.g. for Unreal Engine 4 imports)
-* Set the smoothing type before exporting (e.g. for low poly objects set it to FACE)
-* Define export folder, which is stored to .blend-file
-* Open export folder with one click
-* Export armature and animations
+**Version:** 0.7.0  
+**Author:** jayanam, Rodrigo Camacho (forked from jayanam)
 
-### Installing
-1. Download zip file: https://github.com/jayanam/batex/archive/master.zip
-2. Open Blender
-3. Go to edit -> preferences -> addons
-4. Click install button
-5. Select the zip file you downloaded
-6. Check the box next to "inport-Export: Batex" to enable plugin
+## Description
 
-### Using
-* After installing Batex panel is added to the sidebar (below item/tool/view, right side of 3d viewport)
-* Sidebar can be shown/hidden with the 'n' key.
-* Change options and use the 'Export' button to export
+Batex is a Blender add-on that allows for batch exporting selected objects as FBX files. The add-on is particularly useful for exporting multiple objects with specific configurations like centered transforms, applied transforms, smoothing options, and more.
+
+## Features
+
+- Export multiple selected objects as FBX.
+- Option to center the transform before exporting.
+- Apply transforms like scale and rotation (Experimental).
+- Support for different smoothing options (Edge, Face, Normals Only).
+- Export rig and animations along with the objects.
+- Option to export just one material per object.
+
+## Recent Modifications
+
+### Version 0.7.0
+
+- **Added support for exporting empty objects with children:**
+  - Empty objects are now included in the export process, preserving the parent-child relationship when re-importing the FBX files.
+  - This ensures that the hierarchy is maintained, even if the parent object is an empty object.
+
+- **Improved error handling for objects without materials:**
+  - The export process now checks if an object has mesh data before attempting to access its materials, preventing errors when processing empty objects or other non-mesh types.
+
+## Installation
+
+1. Download the Batex add-on from the repository.
+2. Open Blender and go to `Edit > Preferences > Add-ons`.
+3. Click `Install` and select the downloaded file.
+4. Enable the add-on from the list.
+
+## Usage
+
+1. Open the Batex panel in the 3D view (`N` panel > `Batex`).
+2. Set the export folder, and choose your desired options like centering transforms, applying transforms, etc.
+3. Select the objects you wish to export.
+4. Click `Export` to batch export the selected objects as FBX.
+
+## License
+
+This project is licensed under the GNU General Public License v3.0. See the LICENSE file for details.

--- a/__init__.py
+++ b/__init__.py
@@ -1,9 +1,9 @@
 bl_info = {
     "name" : "Batex",
-    "author" : "jayanam",
+    "author" : "jayanam, Rodrigo Camacho (forked from jayanam)",
     "descrtion" : "Batch export as Fbx",
     "blender" : (2, 80, 0),
-    "version" : (0, 6, 0, 0),
+    "version" : (0, 7, 0, 0),
     "location" : "Batex panel",
     "warning" : "",
     "category" : "Import-Export"
@@ -16,17 +16,17 @@ from . bex_panel import *
 from . bex_op import *
 from . bex_folder_op import *
 
-bpy.types.Scene.export_folder = StringProperty(name="Export folder", 
-               subtype="DIR_PATH", 
-               description="Directory to export the fbx files into")
+bpy.types.Scene.export_folder = StringProperty(name="Export folder",
+                                               subtype="DIR_PATH",
+                                               description="Directory to export the fbx files into")
 
 bpy.types.Scene.center_transform = BoolProperty(name="Center transform",
-                default=True,
-                description="Set the pivot point of the object to the center")
+                                                default=True,
+                                                description="Set the pivot point of the object to the center")
 
 bpy.types.Scene.apply_transform = BoolProperty(name="Apply transform",
-                default=True,
-                description="Applies scale and transform (Experimental)")
+                                               default=True,
+                                               description="Applies scale and transform (Experimental)")
 
 bpy.types.Scene.export_smoothing = EnumProperty(
     name="Smoothing",
@@ -35,21 +35,21 @@ bpy.types.Scene.export_smoothing = EnumProperty(
         ('EDGE', 'Edge', 'Write edge smoothing',0),
         ('FACE', 'Face', 'Write face smoothing',1),
         ('OFF', 'Normals Only', 'Write normals only',2)
-        ),
+    ),
     default='OFF'
-    )
+)
 
 bpy.types.Scene.export_animations = BoolProperty(name="Export Rig & Animations",
-                default=False,
-                description="Export rig and animations")
+                                                 default=False,
+                                                 description="Export rig and animations")
 
 bpy.types.Scene.one_material_ID = BoolProperty(name="One material ID",
-                default=True,
-                description="Export just one material per object")
+                                               default=True,
+                                               description="Export just one material per object")
 
 classes = ( BATEX_PT_Panel, BATEX_OT_Operator, BATEX_OT_OpenFolder )
 
 register, unregister = bpy.utils.register_classes_factory(classes)
-    
+
 if __name__ == "__main__":
     register()


### PR DESCRIPTION
Purpose: Ensure that empty objects with children are included in the FBX export, preserving the parent-child relationship upon re-import.

Changes:

Handling Empty Objects:

Modified the do_export method to include empty objects in the export process.
Added 'EMPTY' to the ex_object_types set, ensuring that both empty objects and their children are exported together.
Parent-Child Relationship Preservation:

By including empty objects during export, the parent-child hierarchy is maintained when the FBX file is re-imported into Blender or another 3D software.
Material Handling:

Updated the remove_materials method to avoid errors when processing objects without mesh data, such as empty objects.